### PR TITLE
add workaround for systems where kernel is not compiled with ksm enabled

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,6 +128,7 @@ if [ ! -e "${PACKAGES}/proxmox-backup-server_${PROXMOX_BACKUP_VER}_arm64.deb" ];
 
 	git_clone_or_fetch https://git.proxmox.com/git/proxmox-backup.git
 	git_clean_and_checkout ${PROXMOX_BACKUP_GIT} proxmox-backup
+	patch -p1 -d proxmox/ < "${PATCHES}/proxmox-no-ksm.patch"
 	patch -p1 -d proxmox-backup/ < "${PATCHES}/proxmox-backup-arm.patch"
 	patch -p1 -d proxmox-backup/ < "${PATCHES}/proxmox-backup-compile.patch"
 	cd proxmox-backup/

--- a/patches/proxmox-no-ksm.patch
+++ b/patches/proxmox-no-ksm.patch
@@ -1,0 +1,27 @@
+diff --git a/proxmox/src/sys/linux/procfs/mod.rs b/proxmox/src/sys/linux/procfs/mod.rs
+index 5784e0e..9259581 100644
+--- a/proxmox/src/sys/linux/procfs/mod.rs
++++ b/proxmox/src/sys/linux/procfs/mod.rs
+@@ -4,6 +4,7 @@ use std::fmt;
+ use std::fs::OpenOptions;
+ use std::io::{BufRead, BufReader};
+ use std::net::{Ipv4Addr, Ipv6Addr};
++use std::path::Path;
+ use std::str::FromStr;
+ use std::sync::RwLock;
+ use std::time::Instant;
+@@ -455,8 +456,12 @@ pub fn read_meminfo() -> Result<ProcFsMemInfo, Error> {
+ 
+     meminfo.swapused = meminfo.swaptotal - meminfo.swapfree;
+ 
+-    let spages_line = file_read_firstline("/sys/kernel/mm/ksm/pages_sharing")?;
+-    meminfo.memshared = spages_line.trim_end().parse::<u64>()? * 4096;
++    if Path::new("/sys/kernel/mm/ksm/pages_sharing").exists() {
++        let spages_line = file_read_firstline("/sys/kernel/mm/ksm/pages_sharing")?;
++        meminfo.memshared = spages_line.trim_end().parse::<u64>()? * 4096;
++    } else {
++        meminfo.memshared = 0;
++    }
+ 
+     Ok(meminfo)
+ }


### PR DESCRIPTION
On systems where the kernel was compiled without ksm enabled (`CONFIG_KSM=y`), the status display on the dashboard and the corresponding RRD graphs in the administration area do not work.
This is e.g. the case on the Raspberry Pi with the Raspberry Pi kernel (see https://github.com/raspberrypi/linux/issues/1238).

To get the monitor working anyway, it is necessary to skip the section in the code that reads the Kernel Samepage Merging size if the file to be read does not exist.

This does not affect systems with ksm.