### PR TITLE
[Feature] Add Dockerfile to build arm64 packages using docker buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:bullseye-slim as builder-stage
+
+RUN apt update && apt-get install -y --no-install-recommends \
+	build-essential curl ca-certificates sudo git lintian \
+	pkg-config libudev-dev libssl-dev libapt-pkg-dev libclang-dev \
+	libpam0g-dev
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -sSf | sh -s -- -y
+
+COPY . /build/
+WORKDIR /build
+
+SHELL ["/bin/bash", "-c"]
+RUN source ~/.cargo/env && ./build.sh
+
+FROM scratch
+COPY --from=builder-stage /build/packages/* ./packages/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ SHELL ["/bin/bash", "-c"]
 RUN source ~/.cargo/env && ./build.sh
 
 FROM scratch
-COPY --from=builder-stage /build/packages/* ./packages/
+COPY --from=builder-stage /build/packages/* /

--- a/README.md
+++ b/README.md
@@ -2,26 +2,36 @@
 Script for building Proxmox Backup Server 2.x for Armbian64 based on Bullseye<br />
 At least 4 GB are required for compiling. On devices with low memory, SWAP must be used (see help section).
 
-## Install build essentials and dependencies
+## Manual Build
+### 1. Install build essentials and dependencies
 ```
 apt-get install -y --no-install-recommends \
 	build-essential curl ca-certificates sudo git lintian \
 	pkg-config libudev-dev libssl-dev libapt-pkg-dev libclang-dev \
 	libpam0g-dev
 ```
-## Install ``rustup``
+### 2. Install ``rustup``
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -sSf | sh -s
 source ~/.cargo/env
 ```
 
-## Start build script
+### 3. Start build script
 ```
 ./build.sh
 ```
 
 The compilation can take several hours.<br />
 After that you can find the finished packages in the folder packages/
+
+## Docker Build
+
+You can build arm64 .deb packages using the provided Dockerfile and docker buildx:
+```
+docker buildx build --platform linux/arm64 .
+```
+
+Once the docker build is completed, packages will be copied from the docker build image to a folder named `packages` in the root folder.
 
 ## Install all needed packages
 ### Server

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After that you can find the finished packages in the folder packages/
 
 You can build arm64 .deb packages using the provided Dockerfile and docker buildx:
 ```
-docker buildx build --platform linux/arm64 .
+docker buildx build -o packages --platform linux/arm64 .
 ```
 
 Once the docker build is completed, packages will be copied from the docker build image to a folder named `packages` in the root folder.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 Script for building Proxmox Backup Server 2.x for Armbian64 based on Bullseye<br />
 At least 4 GB are required for compiling. On devices with low memory, SWAP must be used (see help section).
 
-## Manual Build
-### 1. Install build essentials and dependencies
+## Build manually
+### Install build essentials and dependencies
 ```
 apt-get install -y --no-install-recommends \
 	build-essential curl ca-certificates sudo git lintian \
 	pkg-config libudev-dev libssl-dev libapt-pkg-dev libclang-dev \
 	libpam0g-dev
 ```
-### 2. Install ``rustup``
+### Install ``rustup``
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -sSf | sh -s
 source ~/.cargo/env
 ```
 
-### 3. Start build script
+### Start build script
 ```
 ./build.sh
 ```
@@ -24,7 +24,7 @@ source ~/.cargo/env
 The compilation can take several hours.<br />
 After that you can find the finished packages in the folder packages/
 
-## Docker Build
+## Build using docker
 
 You can build arm64 .deb packages using the provided Dockerfile and docker buildx:
 ```


### PR DESCRIPTION
Hi @wofferl !

Thanks for this script. I'm building my packages on my local workstation instead of on a raspberry pi and I send all .deb to my Pis after using a hosted package repo.

I added a dockerfile which allows to run the build script using docker, directly in arm64 format. I figured it could be useful for other people too.

Let me know what you think!