### PR TITLE
Add crosscompililation package pkgconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ dpkg --add-architecture arm64
 apt update && apt-get install -y --no-install-recommends \
                 build-essential crossbuild-essential-arm64 curl ca-certificates sudo git lintian \
                 pkg-config libudev-dev:arm64 libssl-dev:arm64 libapt-pkg-dev:arm64 apt:amd64 \
-                libclang-dev libpam0g-dev:arm64 \
+                libclang-dev libpam0g-dev:arm64 pkgconf:arm64 \
                 qemu-user-binfmt 
 ```
 (apt:amd64 is necessary because libapt-pkg-dev:arm64 would break the dependencies without it)


### PR DESCRIPTION
Without it, OpenSSL cannot be installed.

See this error when installing:
[crossCompPBS_build.log](https://github.com/user-attachments/files/20540003/crossCompPBS_build.log)
